### PR TITLE
special case for 1-argument functions

### DIFF
--- a/src/operator.jl
+++ b/src/operator.jl
@@ -130,7 +130,7 @@ switchblock = Expr(:block)
 for i = B_OP_START:B_OP_END
 	o = OP[i]
 	ex = Expr(:block)
-	if(o==:+ || o==:*)
+	if(o==:+ || o==:* || o ==:^)
         continue
 	else
 		ex = :(@inbounds return $(o)(v[i],v[i+1]))
@@ -153,6 +153,14 @@ switchexpr = Expr(:macrocall, Expr(:.,:Lazy,quot(symbol("@switch"))), :s,switchb
             @inbounds counter *= v[j]
         end
         return counter
+    elseif s == :^
+        @inbounds exponent = v[i+1]
+        @inbounds base = v[i]
+        if exponent == 2
+            return base*base
+        else
+            return base^exponent
+        end
     end
     $switchexpr
 end


### PR DESCRIPTION
- Skip MyArray abstraction: This just added extra overhead. Keep the stack length as a local variable
- Return values instead of using output vector: Saves a few operations/memory lookups
- Some inlining: Less overhead from function calls

Now about 3.3x slower than JuMP for forward evaluations.

Would you mind switching your editor to use 4 spaces instead of tabs? That's the convention for julia code.
